### PR TITLE
fix: use ALLHANDS_BOT_GITHUB_PAT for infra repo access

### DIFF
--- a/.github/workflows/track-llm-support.yml
+++ b/.github/workflows/track-llm-support.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Track all models
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
         run: python scripts/run_all_models.py
 
       - name: Create Pull Request


### PR DESCRIPTION
## Problem

The "Eval Proxy" and "Prod Proxy" columns on https://openhands-llm-support-tracker.vercel.app/ have been showing "Not found" for all models since February 17, 2026.

## Root Cause

The tracking script needs to clone the private `All-Hands-AI/infra` repository to search for:
1. Model names in `k8s/evaluation/litellm.yaml` and `k8s/production/litellm.yaml`  
2. LiteLLM version history in those files

The workflow was using `secrets.GITHUB_TOKEN` which is the default GitHub Actions token that only has access to the current repository, not to `All-Hands-AI/infra`.

## Fix

Use `secrets.ALLHANDS_BOT_GITHUB_PAT` which has cross-repository access to properly detect proxy support timestamps.

## Testing

After merging, trigger the "Track LLM Support" workflow manually to verify the proxy timestamps are populated correctly.