### PR TITLE
Add GPT-5.4 to tier 1 models

### DIFF
--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -79,6 +79,10 @@ MODEL_ALIASES: dict[str, list[str]] = {
     "GPT-5.2-Codex": [
         "gpt-5.2-codex",  # Frontend verified-models.ts
     ],
+    "GPT-5.4": [
+        "gpt-5.4",      # API model name
+        "gpt-5.4-pro",  # Pro variant API model name
+    ],
     # Google Gemini models
     "Gemini-3-Pro": [
         "gemini-3-pro-preview",  # Frontend verified-models.ts

--- a/tests/test_track_llm_support.py
+++ b/tests/test_track_llm_support.py
@@ -84,6 +84,13 @@ class TestModelAliases:
         assert "gemini-3.1-pro" in aliases
         assert "gemini/gemini-3.1-pro" in aliases
 
+    def test_gpt54_has_aliases(self):
+        """GPT-5.4 should have API and pro variant aliases."""
+        aliases = get_model_aliases("GPT-5.4")
+        assert "GPT-5.4" in aliases
+        assert "gpt-5.4" in aliases
+        assert "gpt-5.4-pro" in aliases
+
 
 class TestGetGithubHeaders:
     """Tests for get_github_headers function."""
@@ -134,6 +141,7 @@ class TestGetModelTier:
         assert get_model_tier("GPT-5.2") == 1
         assert get_model_tier("GPT-5.2-Codex") == 1
         assert get_model_tier("GPT-5") == 1
+        assert get_model_tier("GPT-5.4") == 1
 
     def test_glm_is_tier_1(self):
         """GLM models should be tier 1."""


### PR DESCRIPTION
## Summary

Adds GPT-5.4 to the tier 1 models to track in the LLM Support Tracker.

## Changes

- **MODEL_ALIASES**: Added entry for `GPT-5.4` with API aliases:
  - `gpt-5.4` - standard API model name
  - `gpt-5.4-pro` - pro variant API model name
- **Tests**: Added tier classification and alias resolution tests for GPT-5.4

## Notes

- The existing `TIER_1_PATTERNS` regex `r"^GPT-5"` already covers GPT-5.4, so no pattern changes were needed
- GPT-5.4 is OpenAI's latest frontier model, released March 5, 2026
- Available via API as `gpt-5.4` and `gpt-5.4-pro`, and in ChatGPT as "GPT-5.4 Thinking"

## Reference

- [OpenAI GPT-5.4 Announcement](https://openai.com/index/introducing-gpt-5-4/)

## Testing

All 48 tests pass:
```
pytest tests/test_track_llm_support.py -v
# 48 passed
```