### PR TITLE
fix: find FIRST commit with all benchmarks for index_results_timestamp

### DIFF
--- a/frontend/public/all_models.json
+++ b/frontend/public/all_models.json
@@ -3,12 +3,12 @@
     "model_id": "DeepSeek-V3.2-Reasoner",
     "release_date": "2025-12-01",
     "tier": 2,
-    "sdk_support_timestamp": null,
+    "sdk_support_timestamp": "2025-12-10T08:35:23-08:00",
     "frontend_support_timestamp": null,
-    "index_results_timestamp": "2026-02-17T21:39:17-05:00",
-    "eval_proxy_timestamp": null,
-    "prod_proxy_timestamp": null,
-    "litellm_support_timestamp": null
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
+    "eval_proxy_timestamp": "2026-01-14T13:43:57-05:00",
+    "prod_proxy_timestamp": "2026-01-14T12:50:34-05:00",
+    "litellm_support_timestamp": "2025-12-10T08:35:23-08:00"
   },
   {
     "model_id": "GLM-4.7",
@@ -16,7 +16,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2026-01-12T08:13:21-08:00",
     "frontend_support_timestamp": "2026-03-04T12:40:15-03:00",
-    "index_results_timestamp": "2026-03-05T12:25:17-03:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-01-26T08:48:42-08:00",
     "prod_proxy_timestamp": "2026-01-27T12:10:27-08:00",
     "litellm_support_timestamp": "2026-01-12T08:13:21-08:00"
@@ -38,7 +38,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2025-12-17T19:05:41+01:00",
     "frontend_support_timestamp": "2026-01-30T09:15:47-08:00",
-    "index_results_timestamp": "2026-02-17T21:39:01-05:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2025-12-19T12:58:03-06:00",
     "prod_proxy_timestamp": "2025-12-19T12:58:03-06:00",
     "litellm_support_timestamp": "2025-12-19T12:58:03-06:00"
@@ -49,7 +49,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2025-12-19T12:58:03-06:00",
     "frontend_support_timestamp": "2026-01-30T09:15:47-08:00",
-    "index_results_timestamp": "2026-03-05T12:25:17-03:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2025-12-19T12:58:03-06:00",
     "prod_proxy_timestamp": "2025-12-19T12:58:03-06:00",
     "litellm_support_timestamp": "2025-12-19T12:58:03-06:00"
@@ -60,7 +60,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2026-01-18T00:19:21-03:00",
     "frontend_support_timestamp": "2026-02-11T16:57:22Z",
-    "index_results_timestamp": "2026-02-17T21:39:33-05:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-01-14T13:43:57-05:00",
     "prod_proxy_timestamp": "2026-01-14T12:50:34-05:00",
     "litellm_support_timestamp": "2025-12-17T22:47:49+05:30"
@@ -71,7 +71,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2026-01-18T00:19:21-03:00",
     "frontend_support_timestamp": "2026-02-11T16:57:22Z",
-    "index_results_timestamp": "2026-03-05T12:25:17-03:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-01-14T13:43:57-05:00",
     "prod_proxy_timestamp": "2026-01-14T12:50:34-05:00",
     "litellm_support_timestamp": "2025-11-18T16:06:06-08:00"
@@ -82,7 +82,7 @@
     "tier": 2,
     "sdk_support_timestamp": "2025-11-11T12:26:31-05:00",
     "frontend_support_timestamp": null,
-    "index_results_timestamp": "2026-02-17T21:40:23-05:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-01-14T13:43:57-05:00",
     "prod_proxy_timestamp": "2025-11-10T21:02:25+07:00",
     "litellm_support_timestamp": "2025-11-10T21:02:25+07:00"
@@ -93,7 +93,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2026-01-27T12:32:52-08:00",
     "frontend_support_timestamp": null,
-    "index_results_timestamp": "2026-03-05T12:25:17-03:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-02-17T07:43:53-05:00",
     "prod_proxy_timestamp": "2026-02-25T09:51:02-05:00",
     "litellm_support_timestamp": "2026-02-07T12:30:58-08:00"
@@ -104,7 +104,7 @@
     "tier": 2,
     "sdk_support_timestamp": "2026-01-12T08:13:21-08:00",
     "frontend_support_timestamp": null,
-    "index_results_timestamp": "2026-03-05T12:25:17-03:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-01-26T08:48:42-08:00",
     "prod_proxy_timestamp": "2026-01-27T12:10:27-08:00",
     "litellm_support_timestamp": "2026-01-12T08:13:21-08:00"
@@ -115,7 +115,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2026-02-11T16:00:34Z",
     "frontend_support_timestamp": "2026-02-11T16:57:22Z",
-    "index_results_timestamp": "2026-03-05T12:25:17-03:00",
+    "index_results_timestamp": "2026-02-12T01:50:30Z",
     "eval_proxy_timestamp": "2026-02-11T17:13:43Z",
     "prod_proxy_timestamp": "2026-02-11T16:00:34Z",
     "litellm_support_timestamp": "2026-02-11T16:00:34Z"
@@ -126,7 +126,7 @@
     "tier": 2,
     "sdk_support_timestamp": "2026-02-16T17:05:53-08:00",
     "frontend_support_timestamp": null,
-    "index_results_timestamp": "2026-03-05T12:25:17-03:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": null,
     "prod_proxy_timestamp": null,
     "litellm_support_timestamp": "2026-02-16T17:05:53-08:00"
@@ -137,7 +137,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2025-10-17T12:16:16-04:00",
     "frontend_support_timestamp": "2025-07-30T11:12:31-04:00",
-    "index_results_timestamp": "2026-02-17T21:39:40-05:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2025-07-29T18:50:42-04:00",
     "prod_proxy_timestamp": "2025-07-29T18:50:42-04:00",
     "litellm_support_timestamp": "2025-07-29T18:50:42-04:00"
@@ -159,7 +159,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2025-11-25T14:32:24-03:00",
     "frontend_support_timestamp": "2025-12-01T12:09:33+01:00",
-    "index_results_timestamp": "2026-02-17T21:40:07-05:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-01-14T13:43:57-05:00",
     "prod_proxy_timestamp": "2026-01-14T12:50:34-05:00",
     "litellm_support_timestamp": "2025-12-10T08:35:23-08:00"
@@ -170,7 +170,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2026-02-06T13:23:03+01:00",
     "frontend_support_timestamp": "2026-03-02T13:12:48-05:00",
-    "index_results_timestamp": "2026-03-05T12:25:17-03:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-02-06T13:26:15+01:00",
     "prod_proxy_timestamp": "2026-02-09T15:18:01Z",
     "litellm_support_timestamp": "2026-02-05T11:38:54-08:00"
@@ -181,7 +181,7 @@
     "tier": 1,
     "sdk_support_timestamp": "2025-10-17T12:16:16-04:00",
     "frontend_support_timestamp": "2025-09-29T23:27:19-04:00",
-    "index_results_timestamp": "2026-02-17T21:40:14-05:00",
+    "index_results_timestamp": "2026-02-10T07:52:36-03:00",
     "eval_proxy_timestamp": "2026-01-14T13:43:57-05:00",
     "prod_proxy_timestamp": "2025-09-29T13:48:37-04:00",
     "litellm_support_timestamp": "2025-09-29T13:48:37-04:00"

--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -753,18 +753,18 @@ REQUIRED_BENCHMARKS = {"swe-bench", "gaia", "commit0", "swt-bench", "swe-bench-m
 
 def search_index_results_for_model(model_id: str) -> Optional[str]:
     """
-    Search for when a model's results were completed in openhands-index-results.
+    Search for when a model's results were FIRST completed in openhands-index-results.
     
     A model is considered complete only when all 5 required benchmarks are present:
     swe-bench, gaia, commit0, swt-bench, swe-bench-multimodal.
     
-    Uses local git clone to find when the results became complete.
+    Uses local git clone to find the FIRST commit where all required benchmarks were present.
 
     Args:
         model_id: The language model ID to search for
 
     Returns:
-        ISO timestamp of when results were completed, or None if incomplete/not found
+        ISO timestamp of when results were FIRST completed, or None if incomplete/not found
     """
     import subprocess
     
@@ -786,7 +786,7 @@ def search_index_results_for_model(model_id: str) -> Optional[str]:
         if not folder_name:
             return None
         
-        # Check if all required benchmarks are present
+        # Check if all required benchmarks are present in current HEAD
         scores_path = os.path.join(results_dir, folder_name, "scores.json")
         if not os.path.exists(scores_path):
             return None
@@ -801,17 +801,51 @@ def search_index_results_for_model(model_id: str) -> Optional[str]:
             print(f"Warning: {model_id} missing benchmarks: {missing_benchmarks}", file=sys.stderr)
             return None
         
-        # Get the most recent commit that modified scores.json (when results were completed)
+        # Get ALL commits that modified scores.json, oldest first
         result = subprocess.run(
-            ["git", "log", "--format=%aI", "-1", "--", f"results/{folder_name}/scores.json"],
+            ["git", "log", "--format=%H %aI", "--reverse", "--", f"results/{folder_name}/scores.json"],
             cwd=temp_dir,
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=60,
         )
         
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+        
+        # Parse commits (oldest first due to --reverse)
+        commits = []
+        for line in result.stdout.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split(" ", 1)
+            if len(parts) == 2:
+                commits.append((parts[0], parts[1]))  # (sha, date)
+        
+        # Find the FIRST commit where all required benchmarks are present
+        scores_file_path = f"results/{folder_name}/scores.json"
+        for sha, commit_date in commits:
+            # Get file content at this commit
+            show_result = subprocess.run(
+                ["git", "show", f"{sha}:{scores_file_path}"],
+                cwd=temp_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            
+            if show_result.returncode != 0:
+                continue
+            
+            try:
+                commit_scores = json.loads(show_result.stdout)
+                commit_benchmarks = {entry.get("benchmark") for entry in commit_scores}
+                
+                # Check if all required benchmarks are present
+                if REQUIRED_BENCHMARKS.issubset(commit_benchmarks):
+                    return commit_date
+            except (json.JSONDecodeError, TypeError):
+                continue
         
         return None
         


### PR DESCRIPTION
## Problem

PR #32 introduced incorrect data where:
1. `index_results_timestamp` was returning March 5 (most recent modification) instead of the actual first complete date (Feb 10)
2. `DeepSeek-V3.2-Reasoner` lost its `sdk_support_timestamp` and `litellm_support_timestamp` 

## Root Cause

The `search_index_results_for_model` function was using `git log -1` which returns the **most recent** commit that modified `scores.json`. This is wrong - we need the **first** commit where all 5 required benchmarks were present.

## Fix

Changed the function to:
1. Get all commits that modified `scores.json` in oldest-to-newest order (`--reverse`)
2. Iterate through each commit and check the file contents
3. Return the first commit date where all 5 required benchmarks are present

## Changes

- Fixed `search_index_results_for_model` function in `track_llm_support.py`
- Regenerated `all_models.json` with correct data

## Verification

Before fix:
- GLM-4.7 index_results: `2026-03-05T12:25:17-03:00` ❌
- DeepSeek sdk_support: `null` ❌

After fix:
- GLM-4.7 index_results: `2026-02-10T07:52:36-03:00` ✅ (first complete)
- DeepSeek sdk_support: `2025-12-10T08:35:23-08:00` ✅