### PR TITLE
Add GPT-5.3 and GPT-5.3-codex to tier 1 models

### DIFF
--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -79,6 +79,12 @@ MODEL_ALIASES: dict[str, list[str]] = {
     "GPT-5.2-Codex": [
         "gpt-5.2-codex",  # Frontend verified-models.ts
     ],
+    "GPT-5.3": [
+        "gpt-5.3",  # Frontend verified-models.ts
+    ],
+    "GPT-5.3-codex": [
+        "gpt-5.3-codex",  # Frontend verified-models.ts
+    ],
     "GPT-5.4": [
         "gpt-5.4",      # API model name
         "gpt-5.4-pro",  # Pro variant API model name

--- a/tests/test_track_llm_support.py
+++ b/tests/test_track_llm_support.py
@@ -84,6 +84,16 @@ class TestModelAliases:
         assert "gemini-3.1-pro" in aliases
         assert "gemini/gemini-3.1-pro" in aliases
 
+    def test_gpt53_has_aliases(self):
+        """GPT-5.3 models should have lowercase aliases."""
+        aliases = get_model_aliases("GPT-5.3")
+        assert "GPT-5.3" in aliases
+        assert "gpt-5.3" in aliases
+
+        aliases = get_model_aliases("GPT-5.3-codex")
+        assert "GPT-5.3-codex" in aliases
+        assert "gpt-5.3-codex" in aliases
+
     def test_gpt54_has_aliases(self):
         """GPT-5.4 should have API and pro variant aliases."""
         aliases = get_model_aliases("GPT-5.4")
@@ -140,6 +150,8 @@ class TestGetModelTier:
         """GPT-5* models should be tier 1."""
         assert get_model_tier("GPT-5.2") == 1
         assert get_model_tier("GPT-5.2-Codex") == 1
+        assert get_model_tier("GPT-5.3") == 1
+        assert get_model_tier("GPT-5.3-codex") == 1
         assert get_model_tier("GPT-5") == 1
         assert get_model_tier("GPT-5.4") == 1
 


### PR DESCRIPTION
## Description

This PR adds GPT-5.3 and GPT-5.3-codex as tier 1 models to the LLM support tracker.

## Changes

- Added `GPT-5.3` and `GPT-5.3-codex` to `MODEL_ALIASES` in `scripts/track_llm_support.py` with lowercase aliases
- Added tests for tier classification (both models are tier 1 via the existing `^GPT-5` pattern)
- Added tests for alias resolution in `tests/test_track_llm_support.py`

## Testing

All new tests pass:
- ✅ `test_gpt5_is_tier_1` - Verifies both GPT-5.3 and GPT-5.3-codex are classified as tier 1
- ✅ `test_gpt53_has_aliases` - Verifies the aliases are correctly configured

Fixes #34