### PR TITLE
feat: use MODEL_RELEASE_DATES as source of truth for models to track

### DIFF
--- a/.agents/skills/add-new-model/SKILL.md
+++ b/.agents/skills/add-new-model/SKILL.md
@@ -14,11 +14,34 @@ This skill guides the process of adding a new language model to the OpenHands LL
 
 ## Overview
 
-The LLM Support Tracker monitors when language models are supported across the OpenHands ecosystem. When adding a new model, update the configuration in `scripts/track_llm_support.py`.
+The LLM Support Tracker monitors when language models are supported across the OpenHands ecosystem. Adding a new model requires updating two files:
+1. `scripts/run_all_models.py` - Add the model to `MODEL_RELEASE_DATES` (required)
+2. `scripts/track_llm_support.py` - Add aliases to `MODEL_ALIASES` (if needed)
 
 ## Key Components
 
-### 1. TIER_1_PATTERNS
+### 1. MODEL_RELEASE_DATES (Source of Truth)
+
+Located in `scripts/run_all_models.py`, this dictionary is **the source of truth** for which models to track:
+
+```python
+MODEL_RELEASE_DATES = {
+    # Anthropic Claude models
+    "claude-sonnet-4-5": "2025-09-29",
+    "claude-opus-4-6": "2026-02-05",
+    # Google Gemini models
+    "Gemini-3-Pro": "2025-11-18",
+    "Gemini-3.1-Pro": "2026-03-04",
+    # OpenAI GPT models
+    "GPT-5.2": "2025-12-11",
+    "GPT-5.4": "2026-03-05",
+    # ... more models
+}
+```
+
+**When to modify**: Always add new models here with their official release date. Models are tracked immediately even before they have index results or proxy support.
+
+### 2. TIER_1_PATTERNS
 
 Located at the top of `track_llm_support.py`, this list defines regex patterns for tier 1 (priority) models:
 
@@ -52,24 +75,37 @@ MODEL_ALIASES: dict[str, list[str]] = {
 }
 ```
 
-**When to modify**: Always add a new entry when supporting a new model. Include all known aliases for the model.
+**When to modify**: Add aliases when the model uses different names across systems (frontend, SDK, LiteLLM, proxy).
 
 ## Adding a New Model
 
-### Step 1: Determine Model Tier
+### Step 1: Add to MODEL_RELEASE_DATES (Required)
+
+Add the model to `MODEL_RELEASE_DATES` in `scripts/run_all_models.py` with its official release date:
+
+```python
+MODEL_RELEASE_DATES = {
+    # ... existing models ...
+    "New-Model-Name": "2026-03-15",  # Official release date
+}
+```
+
+This is **required** - the model won't be tracked without this entry.
+
+### Step 2: Determine Model Tier
 
 Check if the model should be tier 1 (priority) or tier 2:
 - **Tier 1**: Major models from leading providers (Claude Sonnet/Opus, Gemini Pro/Flash, GPT-5*, GLM, Qwen3-Coder-*, MiniMax-M2.5, Kimi-K2.5)
 - **Tier 2**: All other models
 
-### Step 2: Check Tier Pattern Coverage
+### Step 3: Check Tier Pattern Coverage
 
-If adding a tier 1 model, verify the existing `TIER_1_PATTERNS` regex patterns. Only add a new pattern if no existing pattern matches the model ID.
+If adding a tier 1 model, verify the existing `TIER_1_PATTERNS` regex patterns in `scripts/track_llm_support.py`. Only add a new pattern if no existing pattern matches the model ID.
 
-### Step 3: Add to MODEL_ALIASES
+### Step 4: Add to MODEL_ALIASES (If Needed)
 
-Add an entry to `MODEL_ALIASES` with:
-- **Key**: The canonical model ID (e.g., `"Gemini-3.1-Pro"`)
+If the model uses different names across systems, add an entry to `MODEL_ALIASES` in `scripts/track_llm_support.py`:
+- **Key**: The canonical model ID (must match the key in `MODEL_RELEASE_DATES`)
 - **Value**: List of aliases used across different systems:
   - Frontend `verified-models.ts` names
   - LiteLLM naming conventions (e.g., `provider/model-name`)
@@ -85,7 +121,7 @@ Example:
 ],
 ```
 
-### Step 4: Add Tests
+### Step 5: Add Tests
 
 Add test cases to `tests/test_track_llm_support.py`:
 
@@ -104,7 +140,7 @@ Add test cases to `tests/test_track_llm_support.py`:
        assert "gemini-3.1-pro-preview" in aliases
    ```
 
-### Step 5: Run Tests
+### Step 6: Run Tests
 
 ```bash
 cd llm-support-tracker
@@ -114,15 +150,17 @@ pytest tests/ -v
 
 ## Validation Checklist
 
+- [ ] Model added to `MODEL_RELEASE_DATES` with correct release date
 - [ ] Model ID follows canonical naming convention
 - [ ] Tier 1 models are covered by `TIER_1_PATTERNS` regex
-- [ ] `MODEL_ALIASES` entry includes all known aliases
+- [ ] `MODEL_ALIASES` entry includes all known aliases (if needed)
 - [ ] Tests added for tier classification
-- [ ] Tests added for alias resolution
+- [ ] Tests added for alias resolution (if aliases added)
 - [ ] All tests pass
 
 ## File Locations
 
-- **Main script**: `scripts/track_llm_support.py`
+- **Model registry (source of truth)**: `scripts/run_all_models.py` - `MODEL_RELEASE_DATES`
+- **Tier patterns & aliases**: `scripts/track_llm_support.py`
 - **Tests**: `tests/test_track_llm_support.py`
 - **Dependencies**: `requirements.txt`

--- a/scripts/run_all_models.py
+++ b/scripts/run_all_models.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-Script to run the LLM support tracker for all models in openhands-index-results.
+Script to run the LLM support tracker for all models.
 
-Outputs a single all_models.json file as the source of truth.
+MODEL_RELEASE_DATES is the source of truth for which models to track.
+Outputs a single all_models.json file.
 """
 
 import json
@@ -19,23 +20,27 @@ from track_llm_support import (
     cleanup_sdk_cache,
     cleanup_frontend_cache,
     cleanup_index_results_cache,
-    _get_index_results_repo,
 )
 
 
-# Release dates for known models (verified from official sources)
+# MODEL_RELEASE_DATES is the source of truth for which models to track.
+# Add new models here with their official release dates.
+# Models are tracked even before they have index results or proxy support.
 MODEL_RELEASE_DATES = {
+    # Anthropic Claude models
+    "claude-sonnet-4-5": "2025-09-29",
+    "claude-sonnet-4-6": "2026-02-20",
+    "claude-opus-4-5": "2025-11-24",
+    "claude-opus-4-6": "2026-02-05",
     # DeepSeek models
     "DeepSeek-V3.2-Reasoner": "2025-12-01",
     # GLM models (Z-AI/Zhipu)
     "GLM-4.7": "2025-10-01",
     "GLM-5": "2026-02-01",
-    # OpenAI GPT models
-    "GPT-5.2-Codex": "2025-12-18",
-    "GPT-5.2": "2025-12-11",
     # Google Gemini models
-    "Gemini-3-Flash": "2025-12-17",
     "Gemini-3-Pro": "2025-11-18",
+    "Gemini-3-Flash": "2025-12-17",
+    "Gemini-3.1-Pro": "2026-03-04",
     # Moonshot Kimi models
     "Kimi-K2-Thinking": "2025-11-06",
     "Kimi-K2.5": "2026-01-27",
@@ -44,48 +49,20 @@ MODEL_RELEASE_DATES = {
     "MiniMax-M2.5": "2026-02-01",
     # NVIDIA Nemotron models
     "Nemotron-3-Nano": "2025-10-01",
+    # OpenAI GPT models
+    "GPT-5.2": "2025-12-11",
+    "GPT-5.2-Codex": "2025-12-18",
+    "GPT-5.4": "2026-03-05",
     # Alibaba Qwen models
-    "Qwen3-Coder-480B": "2025-07-23",  # Announced July 23, 2025
+    "Qwen3-Coder-480B": "2025-07-23",
     "Qwen3-Coder-Next": "2026-01-15",
-    # Anthropic Claude models
-    "claude-opus-4-5": "2025-11-24",
-    "claude-opus-4-6": "2026-02-05",
-    "claude-sonnet-4-5": "2025-09-29",
-    "claude-sonnet-4-6": "2026-02-20",
 }
 
 
-def get_models_from_index_results() -> list[str]:
-    """Get list of model folders from openhands-index-results using local git clone."""
-    try:
-        cache = _get_index_results_repo()
-        temp_dir = cache["temp_dir"]
-        
-        results_dir = os.path.join(temp_dir, "results")
-        if not os.path.exists(results_dir):
-            print("No results directory found!")
-            return []
-        
-        models = []
-        for name in os.listdir(results_dir):
-            if os.path.isdir(os.path.join(results_dir, name)):
-                models.append(name)
-        
-        return sorted(models)
-    except Exception as e:
-        print(f"Error fetching models: {e}")
-        return []
-
-
 def main():
-    print("Fetching models from openhands-index-results...")
-    models = get_models_from_index_results()
-
-    if not models:
-        print("No models found!")
-        sys.exit(1)
-
-    print(f"Found {len(models)} models: {models}")
+    # Use MODEL_RELEASE_DATES as the source of truth
+    models = sorted(MODEL_RELEASE_DATES.keys())
+    print(f"Tracking {len(models)} models from MODEL_RELEASE_DATES: {models}")
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     # Write directly to frontend/public - the single source of truth
@@ -98,8 +75,7 @@ def main():
         print(f"Processing: {model}")
         print("=" * 60)
 
-        # Get release date (use default if not known)
-        release_date = MODEL_RELEASE_DATES.get(model, "2025-01-01")
+        release_date = MODEL_RELEASE_DATES[model]
 
         try:
             result = track_llm_support(model, release_date)


### PR DESCRIPTION
## Summary

Changes the model discovery logic so that `MODEL_RELEASE_DATES` is the single source of truth for which models to track.

## Problem

Previously, the script discovered models by listing folders in `openhands-index-results`. This meant:
- New models couldn't be tracked until they had benchmark results
- GPT-5.4 and Gemini-3.1-Pro (recently added to the repo) weren't being picked up

## Solution

- Use `MODEL_RELEASE_DATES` dictionary as the source of truth
- Models are tracked immediately when added to the dictionary
- No longer depends on `openhands-index-results` for model discovery (still uses it for index_results_timestamp)

## New Models Added

- **GPT-5.4** (released 2026-03-05)
- **Gemini-3.1-Pro** (released 2026-03-04)

## How to Add New Models

1. Add the model to `MODEL_RELEASE_DATES` in `scripts/run_all_models.py`
2. Add aliases to `MODEL_ALIASES` in `scripts/track_llm_support.py` (if needed)
3. The workflow will pick it up on the next run

## Testing

After merging, trigger the update workflow to verify GPT-5.4 and Gemini-3.1-Pro are tracked.