### PR TITLE
Fix SaaS frontend confirmation and tracker semantics

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -5,8 +5,9 @@ import {
   computeFamilyChartData,
   computeAverageChartData,
   applyRollingAverage,
-  getWeeklySampleDates,
+  getWeeklySampleDates
 } from './App';
+import { getFrontendSupportStatus } from './frontendSupport';
 
 interface ModelSupport {
   model_id: string;
@@ -14,11 +15,43 @@ interface ModelSupport {
   tier: number;
   sdk_support_timestamp: string | null;
   frontend_support_timestamp: string | null;
+  frontend_saas_available: boolean;
   index_results_timestamp: string | null;
   eval_proxy_timestamp: string | null;
   prod_proxy_timestamp: string | null;
   litellm_support_timestamp: string | null;
 }
+
+
+describe('getFrontendSupportStatus', () => {
+  it('should return full when frontend timestamp and SaaS availability both exist', () => {
+    expect(getFrontendSupportStatus({
+      frontend_support_timestamp: '2024-01-02T00:00:00Z',
+      frontend_saas_available: true,
+    })).toBe('full');
+  });
+
+  it('should return frontend_only when only frontend timestamp is known', () => {
+    expect(getFrontendSupportStatus({
+      frontend_support_timestamp: '2024-01-02T00:00:00Z',
+      frontend_saas_available: false,
+    })).toBe('frontend_only');
+  });
+
+  it('should return saas_only when only SaaS availability is known', () => {
+    expect(getFrontendSupportStatus({
+      frontend_support_timestamp: null,
+      frontend_saas_available: true,
+    })).toBe('saas_only');
+  });
+
+  it('should return not_found when neither frontend timestamp nor SaaS availability exists', () => {
+    expect(getFrontendSupportStatus({
+      frontend_support_timestamp: null,
+      frontend_saas_available: false,
+    })).toBe('not_found');
+  });
+});
 
 describe('isModelSupportedForAspect', () => {
   const testModel: ModelSupport = {
@@ -27,6 +60,7 @@ describe('isModelSupportedForAspect', () => {
     release_date: '2024-01-01',
     sdk_support_timestamp: '2024-01-05T00:00:00Z',
     frontend_support_timestamp: null,
+    frontend_saas_available: false,
     index_results_timestamp: '2024-01-03T00:00:00Z',
     eval_proxy_timestamp: '2024-01-10T00:00:00Z',
     prod_proxy_timestamp: null,
@@ -64,6 +98,7 @@ describe('isModelSupportedForAspect', () => {
       release_date: '2024-01-01',
       sdk_support_timestamp: '2024-01-02T00:00:00Z',
       frontend_support_timestamp: '2024-01-02T00:00:00Z',
+      frontend_saas_available: true,
       index_results_timestamp: '2024-01-02T00:00:00Z',
       eval_proxy_timestamp: '2024-01-02T00:00:00Z',
       prod_proxy_timestamp: '2024-01-02T00:00:00Z',
@@ -83,6 +118,7 @@ describe('computeDaysUnsupported', () => {
         release_date: '2024-01-01',
         sdk_support_timestamp: null,
         frontend_support_timestamp: null,
+    frontend_saas_available: false,
         index_results_timestamp: null,
         eval_proxy_timestamp: null,
         prod_proxy_timestamp: null,
@@ -101,6 +137,7 @@ describe('computeDaysUnsupported', () => {
         release_date: '2024-01-01',
         sdk_support_timestamp: null,
         frontend_support_timestamp: null,
+    frontend_saas_available: false,
         index_results_timestamp: null,
         eval_proxy_timestamp: null,
         prod_proxy_timestamp: null,
@@ -137,6 +174,7 @@ describe('computeDaysUnsupported', () => {
         release_date: releaseDate,
         sdk_support_timestamp: null,
         frontend_support_timestamp: null,
+    frontend_saas_available: false,
         index_results_timestamp: null,
         eval_proxy_timestamp: null,
         prod_proxy_timestamp: null,
@@ -164,6 +202,7 @@ describe('computeDaysUnsupported', () => {
         release_date: '2024-01-01',
         sdk_support_timestamp: null,
         frontend_support_timestamp: null,
+    frontend_saas_available: false,
         index_results_timestamp: null,
         eval_proxy_timestamp: null,
         prod_proxy_timestamp: null,
@@ -175,6 +214,7 @@ describe('computeDaysUnsupported', () => {
         release_date: '2024-01-03',
         sdk_support_timestamp: null,
         frontend_support_timestamp: null,
+    frontend_saas_available: false,
         index_results_timestamp: null,
         eval_proxy_timestamp: null,
         prod_proxy_timestamp: null,
@@ -273,6 +313,7 @@ describe('computeFamilyChartData', () => {
         release_date: '2024-01-01',
         sdk_support_timestamp: '2024-01-02T00:00:00Z',
         frontend_support_timestamp: '2024-01-03T00:00:00Z',
+        frontend_saas_available: true,
         index_results_timestamp: '2024-01-04T00:00:00Z',
         eval_proxy_timestamp: '2024-01-05T00:00:00Z',
         prod_proxy_timestamp: '2024-01-06T00:00:00Z',
@@ -304,6 +345,7 @@ describe('computeFamilyChartData', () => {
         release_date: '2024-01-01',
         sdk_support_timestamp: null,
         frontend_support_timestamp: null,
+    frontend_saas_available: false,
         index_results_timestamp: null,
         eval_proxy_timestamp: null,
         prod_proxy_timestamp: null,
@@ -327,6 +369,7 @@ describe('computeFamilyChartData', () => {
         release_date: '2024-01-01',
         sdk_support_timestamp: null,
         frontend_support_timestamp: null,
+    frontend_saas_available: false,
         index_results_timestamp: null,
         eval_proxy_timestamp: null,
         prod_proxy_timestamp: null,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
+import { getFrontendSupportStatus } from './frontendSupport';
 
 interface ModelSupport {
   model_id: string;
@@ -16,6 +17,7 @@ interface ModelSupport {
   tier: number;
   sdk_support_timestamp: string | null;
   frontend_support_timestamp: string | null;
+  frontend_saas_available: boolean;
   index_results_timestamp: string | null;
   eval_proxy_timestamp: string | null;
   prod_proxy_timestamp: string | null;
@@ -356,6 +358,40 @@ function StatusBadge({ timestamp }: { timestamp: string | null }) {
   );
 }
 
+function FrontendStatusBadge({ model }: { model: ModelSupport }) {
+  const status = getFrontendSupportStatus(model);
+
+  if (status === 'full') {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-900/50 text-green-400 border border-green-700">
+        ✓ Frontend + SaaS
+      </span>
+    );
+  }
+
+  if (status === 'frontend_only') {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-900/40 text-blue-300 border border-blue-700/70">
+        △ Frontend only
+      </span>
+    );
+  }
+
+  if (status === 'saas_only') {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-900/40 text-amber-300 border border-amber-700/70">
+        △ SaaS only
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-800 text-gray-400 border border-gray-700">
+      — Not found
+    </span>
+  );
+}
+
 function App() {
   const [models, setModels] = useState<ModelSupport[]>([]);
   const [sortField, setSortField] = useState<keyof ModelSupport>('model_id');
@@ -528,7 +564,7 @@ function App() {
                     className="px-4 py-3 text-left text-sm font-semibold text-[#c4cbda] cursor-pointer hover:bg-[#31343d]"
                     onClick={() => handleSort('frontend_support_timestamp')}
                   >
-                    Frontend <SortIcon field="frontend_support_timestamp" />
+                    Frontend / SaaS <SortIcon field="frontend_support_timestamp" />
                   </th>
                   <th
                     className="px-4 py-3 text-left text-sm font-semibold text-[#c4cbda] cursor-pointer hover:bg-[#31343d]"
@@ -606,13 +642,23 @@ function App() {
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex flex-col gap-1">
-                        <StatusBadge timestamp={model.frontend_support_timestamp} />
+                        <FrontendStatusBadge model={model} />
                         {model.frontend_support_timestamp && (
                           <span className="text-xs text-[#9099ac]">
                             {formatDate(model.frontend_support_timestamp)}
                             <span className="ml-1 text-blue-400">
                               ({getDaysDiff(model.frontend_support_timestamp, model.release_date)})
                             </span>
+                          </span>
+                        )}
+                        {model.frontend_support_timestamp && !model.frontend_saas_available && (
+                          <span className="text-xs text-blue-300">
+                            Self-hosted frontend support confirmed; SaaS availability not confirmed
+                          </span>
+                        )}
+                        {!model.frontend_support_timestamp && model.frontend_saas_available && (
+                          <span className="text-xs text-amber-300">
+                            Currently available in SaaS; self-hosted timestamp not found
                           </span>
                         )}
                       </div>
@@ -667,10 +713,11 @@ function App() {
             </p>
           </div>
           <div className="bg-[#1f2228] rounded-lg border border-[#3c3c4a] p-4">
-            <h3 className="text-sm font-medium text-[#9099ac]">Frontend</h3>
+            <h3 className="text-sm font-medium text-[#9099ac]">Frontend / SaaS</h3>
             <p className="text-2xl font-bold text-green-400 mt-1">
-              {models.filter((m) => m.frontend_support_timestamp).length}
+              {models.filter((m) => getFrontendSupportStatus(m) !== 'not_found').length}
             </p>
+            <p className="text-xs text-[#9099ac] mt-1">Includes SaaS-only availability</p>
           </div>
           <div className="bg-[#1f2228] rounded-lg border border-[#3c3c4a] p-4">
             <h3 className="text-sm font-medium text-[#9099ac]">Index Results</h3>

--- a/frontend/src/frontendSupport.ts
+++ b/frontend/src/frontendSupport.ts
@@ -1,0 +1,21 @@
+export interface FrontendStatusModel {
+  frontend_support_timestamp: string | null;
+  frontend_saas_available: boolean;
+}
+
+export type FrontendSupportStatus = 'full' | 'frontend_only' | 'saas_only' | 'not_found';
+
+export function getFrontendSupportStatus(
+  model: FrontendStatusModel
+): FrontendSupportStatus {
+  if (model.frontend_support_timestamp && model.frontend_saas_available) {
+    return 'full';
+  }
+  if (model.frontend_support_timestamp) {
+    return 'frontend_only';
+  }
+  if (model.frontend_saas_available) {
+    return 'saas_only';
+  }
+  return 'not_found';
+}

--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -585,11 +585,17 @@ def check_saas_verified_model(model_id: str) -> bool:
                 continue
             if "/" in alias_lower:
                 continue
-            # Skip LiteLLM provider-specific prefixes (zai., moonshotai., etc.)
-            # but add ALL other simple aliases that could match SaaS model names
-            if alias_lower.startswith(("zai.", "moonshotai.", "minimax.", "qwen.", "nvidia.")):
-                continue
-            saas_aliases.add(alias_lower)
+            # Add aliases matching SaaS model name patterns:
+            # - Preview suffixes (e.g., "-preview")
+            # - Date-stamped versions (e.g., "-251222")
+            # These are the standard formats used in the frontend verified-models.ts
+            if alias_lower.endswith("-preview") or re.search(r"-\d{8}$", alias_lower):
+                saas_aliases.add(alias_lower)
+            # Also add the simple lowercase model ID itself for models with mixed case
+            # (e.g., "claude-opus-4-6" -> "claude-opus-4-6") to ensure they match
+            # even without -preview or date suffixes
+            elif model_id != model_lower and alias_lower == model_lower:
+                saas_aliases.add(alias_lower)
 
         for model in models:
             model_lower = model.lower()

--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -585,10 +585,11 @@ def check_saas_verified_model(model_id: str) -> bool:
                 continue
             if "/" in alias_lower:
                 continue
+            # Skip LiteLLM provider-specific prefixes (zai., moonshotai., etc.)
+            # but add ALL other simple aliases that could match SaaS model names
             if alias_lower.startswith(("zai.", "moonshotai.", "minimax.", "qwen.", "nvidia.")):
                 continue
-            if alias_lower.endswith("-preview") or re.search(r"-\d{8}$", alias_lower):
-                saas_aliases.add(alias_lower)
+            saas_aliases.add(alias_lower)
 
         for model in models:
             model_lower = model.lower()

--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -541,79 +541,184 @@ def search_frontend_for_model(model_id: str) -> Optional[str]:
         return None
 
 
-def check_saas_verified_model(model_id: str) -> bool:
+def _extract_saas_model_names(payload) -> Optional[list[str]]:
+    """Extract model identifiers from supported SaaS API response shapes."""
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, str)]
+
+    if isinstance(payload, dict):
+        if isinstance(payload.get("verified_models"), list):
+            return [item for item in payload["verified_models"] if isinstance(item, str)]
+
+        if isinstance(payload.get("models"), list):
+            return [item for item in payload["models"] if isinstance(item, str)]
+
+        if isinstance(payload.get("items"), list):
+            models = []
+            for item in payload["items"]:
+                if not isinstance(item, dict):
+                    continue
+                provider = item.get("provider")
+                name = item.get("name")
+                if provider and name:
+                    models.append(f"{provider}/{name}")
+                elif name:
+                    models.append(name)
+            return models
+
+    return None
+
+
+def _fetch_json_payload(url: str, headers: dict, params: dict | None = None):
+    """Fetch JSON from a SaaS endpoint, rejecting HTML/app-shell responses."""
+    response = requests.get(url, headers=headers, params=params, timeout=30)
+    response.raise_for_status()
+
+    content_type = response.headers.get("content-type", "").lower()
+    if "json" not in content_type and not response.text.lstrip().startswith(("[", "{")):
+        raise ValueError(
+            f"non-JSON response from {response.url} ({content_type or 'unknown content-type'})"
+        )
+
+    return response.json()
+
+
+def _fetch_saas_models_v1(headers: dict) -> list[str]:
+    """Fetch SaaS OpenHands-provider models from the v1 config API."""
+    models = []
+    page_id = None
+
+    for _ in range(20):
+        params = {"provider__eq": "openhands", "limit": 100}
+        if page_id:
+            params["page_id"] = page_id
+
+        payload = _fetch_json_payload(
+            "https://app.all-hands.dev/api/v1/config/models/search",
+            headers,
+            params=params,
+        )
+        page_models = _extract_saas_model_names(payload)
+        if page_models is None:
+            raise ValueError("unsupported JSON payload shape from /api/v1/config/models/search")
+
+        models.extend(page_models)
+
+        if not isinstance(payload, dict):
+            break
+        page_id = payload.get("next_page_id")
+        if not page_id:
+            break
+    else:
+        raise ValueError("too many pages returned from /api/v1/config/models/search")
+
+    return models
+
+
+def _fetch_saas_models() -> Optional[list[str]]:
+    """Fetch the current SaaS model list, returning None when it cannot be confirmed."""
+    api_keys = [
+        ("OPENHANDS_CLOUD_API_KEY", os.environ.get("OPENHANDS_CLOUD_API_KEY")),
+        ("LLM_API_KEY", os.environ.get("LLM_API_KEY")),
+    ]
+    api_keys = [(name, value) for name, value in api_keys if value]
+
+    if not api_keys:
+        print(
+            "Warning: no API key available, cannot confirm SaaS verified models",
+            file=sys.stderr,
+        )
+        return None
+
+    legacy_urls = [
+        "https://app.all-hands.dev/api/options/models",
+        "https://app.all-hands.dev/api/public/options/models",
+    ]
+
+    last_error = None
+    for _key_name, api_key in api_keys:
+        headers_list = [
+            {"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+            {"X-Access-Token": api_key, "Accept": "application/json"},
+        ]
+
+        for headers in headers_list:
+            try:
+                models = _fetch_saas_models_v1(headers)
+                if models:
+                    return models
+                last_error = "empty model list from /api/v1/config/models/search"
+            except Exception as exc:
+                last_error = str(exc)
+
+            for url in legacy_urls:
+                try:
+                    payload = _fetch_json_payload(url, headers)
+                    models = _extract_saas_model_names(payload)
+                    if models is not None:
+                        return models
+                    last_error = f"unsupported JSON payload shape from {url}"
+                except Exception as exc:
+                    last_error = str(exc)
+                    continue
+
+    if last_error:
+        print(f"Warning: Error checking SaaS verified models: {last_error}", file=sys.stderr)
+    return None
+
+
+def check_saas_verified_model(model_id: str) -> Optional[bool]:
     """
     Check if a model is currently in the SaaS verified_models database.
-    
-    Queries the app.all-hands.dev API to check if the model appears in the
+
+    Queries the app.all-hands.dev APIs to check if the model appears in the
     openhands provider's model list. This indicates the model is available
     in the production SaaS dropdown.
-    
-    Requires LLM_API_KEY environment variable to be set.
-    
+
+    Returns ``None`` when the live SaaS model list cannot be confirmed.
+
     Args:
         model_id: The language model ID to check
-        
+
     Returns:
-        True if model is in the SaaS verified models, False otherwise
+        True if model is in the SaaS verified models, False if confirmed absent,
+        or None if the SaaS model list could not be fetched.
     """
-    api_key = os.environ.get("LLM_API_KEY")
-    if not api_key:
-        print("Warning: LLM_API_KEY not set, cannot check SaaS verified models", 
-              file=sys.stderr)
-        return False
-    
-    try:
-        response = requests.get(
-            "https://app.all-hands.dev/api/options/models",
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=30,
-        )
-        response.raise_for_status()
-        models = response.json()
-        
-        # The SaaS API may return OpenHands models as either:
-        # - openhands/model-name
-        # - bare model-name (as shown in the settings UI)
-        # Match the canonical ID plus frontend-style aliases, but ignore
-        # provider-specific LiteLLM aliases.
-        model_lower = model_id.lower()
-        saas_aliases = {model_lower}
-        for alias in get_model_aliases(model_id):
-            alias_lower = alias.lower()
-            if alias_lower == model_lower:
-                continue
-            if "/" in alias_lower:
-                continue
-            # Add aliases matching SaaS model name patterns:
-            # - Preview suffixes (e.g., "-preview")
-            # - Date-stamped versions (e.g., "-251222")
-            # These are the standard formats used in the frontend verified-models.ts
-            if alias_lower.endswith("-preview") or re.search(r"-\d{8}$", alias_lower):
-                saas_aliases.add(alias_lower)
-            # Also add the simple lowercase model ID itself for models with mixed case
-            # (e.g., "claude-opus-4-6" -> "claude-opus-4-6") to ensure they match
-            # even without -preview or date suffixes
-            elif model_id != model_lower and alias_lower == model_lower:
-                saas_aliases.add(alias_lower)
+    models = _fetch_saas_models()
+    if models is None:
+        return None
 
-        for model in models:
-            model_lower = model.lower()
-            if model_lower.startswith("openhands/"):
-                model_name = model_lower[len("openhands/"):]
-            elif "/" not in model_lower:
-                model_name = model_lower
-            else:
-                continue
+    # The SaaS API may return OpenHands models as either:
+    # - openhands/model-name
+    # - bare model-name (as shown in the settings UI)
+    # Match the canonical ID plus frontend-style aliases, but ignore
+    # provider-specific LiteLLM aliases.
+    model_lower = model_id.lower()
+    saas_aliases = {model_lower}
+    for alias in get_model_aliases(model_id):
+        alias_lower = alias.lower()
+        if alias_lower == model_lower:
+            continue
+        if "/" in alias_lower:
+            continue
+        if alias_lower.startswith(("zai.", "moonshotai.", "minimax.", "qwen.", "nvidia.")):
+            continue
+        if alias_lower.endswith("-preview") or re.search(r"-\d{8}$", alias_lower):
+            saas_aliases.add(alias_lower)
 
-            if model_name in saas_aliases:
-                return True
+    for model in models:
+        model_lower = model.lower()
+        if model_lower.startswith("openhands/"):
+            model_name = model_lower[len("openhands/"):]
+        elif "/" not in model_lower:
+            model_name = model_lower
+        else:
+            continue
 
-        return False
-        
-    except Exception as e:
-        print(f"Warning: Error checking SaaS verified models: {e}", file=sys.stderr)
-        return False
+        if model_name in saas_aliases:
+            return True
+
+    return False
 
 
 # Module-level cache for litellm repo
@@ -1332,20 +1437,16 @@ def track_llm_support(model_id: str, release_date: str) -> dict:
     print(f"Searching for {model_id} in OpenHands frontend...")
     frontend_code_timestamp = search_frontend_for_model(model_id)
 
-    # Check if model is currently available in SaaS verified_models database
-    # Since PR #12833, SaaS uses a database instead of verified-models.ts
-    # A model is only considered "frontend supported" when it's in BOTH:
-    # 1. verified-models.ts (for self-hosted)
-    # 2. SaaS verified_models database (for app.all-hands.dev)
+    # Check if model is currently available in SaaS verified_models database.
+    # This is best-effort: if the live SaaS API cannot be confirmed, keep the
+    # self-hosted frontend timestamp instead of regressing known frontend support.
     print(f"Checking if {model_id} is in SaaS verified models...")
     saas_available = check_saas_verified_model(model_id)
-    result["frontend_saas_available"] = saas_available
+    result["frontend_saas_available"] = saas_available is True
 
-    # Only set frontend_support_timestamp if model is available in both places
-    if frontend_code_timestamp and saas_available:
-        result["frontend_support_timestamp"] = frontend_code_timestamp
-    else:
-        result["frontend_support_timestamp"] = None
+    # Frontend support timestamp reflects self-hosted/frontend-code support.
+    # SaaS availability is tracked separately in frontend_saas_available.
+    result["frontend_support_timestamp"] = frontend_code_timestamp
 
     # Search for index results using local git clone
     # Note: No adjust_timestamp_to_release - index requires explicit model additions

--- a/tests/test_track_llm_support.py
+++ b/tests/test_track_llm_support.py
@@ -619,18 +619,41 @@ class TestTrackLlmSupport:
         self, mock_search_sdk, mock_search_frontend, mock_search_index, mock_search_infra, 
         mock_find_versions, mock_check_saas
     ):
-        """Test that frontend_support_timestamp is None when only in code but not SaaS."""
+        """Test that frontend code support is preserved even when SaaS is not confirmed."""
         mock_search_sdk.return_value = "2024-01-20T10:00:00Z"
         mock_search_frontend.return_value = "2024-01-25T10:00:00Z"  # In code
-        mock_check_saas.return_value = False  # NOT in SaaS database
+        mock_check_saas.return_value = False  # Not confirmed in SaaS database
         mock_search_index.return_value = None
         mock_search_infra.side_effect = [None, None]
         mock_find_versions.return_value = []
 
         result = track_llm_support("test-model", "2024-01-15")
 
-        # frontend_support_timestamp should be None because model is not in SaaS
-        assert result["frontend_support_timestamp"] is None
+        assert result["frontend_support_timestamp"] == "2024-01-25T10:00:00Z"
+        assert result["frontend_saas_available"] is False
+
+    @patch("track_llm_support.check_saas_verified_model")
+    @patch("track_llm_support.find_litellm_versions_supporting_model")
+    @patch("track_llm_support.search_infra_proxy")
+    @patch("track_llm_support.search_index_results_for_model")
+    @patch("track_llm_support.search_frontend_for_model")
+    @patch("track_llm_support.search_sdk_for_model")
+    def test_track_llm_support_frontend_code_preserved_when_saas_check_unavailable(
+        self, mock_search_sdk, mock_search_frontend, mock_search_index, mock_search_infra,
+        mock_find_versions, mock_check_saas
+    ):
+        """Test that an unavailable SaaS check does not erase known frontend code support."""
+        mock_search_sdk.return_value = "2024-01-20T10:00:00Z"
+        mock_search_frontend.return_value = "2024-01-25T10:00:00Z"
+        mock_check_saas.return_value = None
+        mock_search_index.return_value = None
+        mock_search_infra.side_effect = [None, None]
+        mock_find_versions.return_value = []
+
+        result = track_llm_support("test-model", "2024-01-15")
+
+        assert result["frontend_support_timestamp"] == "2024-01-25T10:00:00Z"
+        assert result["frontend_saas_available"] is False
 
 
 class TestOutputFormat:
@@ -740,6 +763,8 @@ class TestCheckSaasVerifiedModel:
     def test_model_found_in_saas(self, mock_get):
         """Test that a model in the openhands provider list returns True."""
         mock_response = MagicMock()
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = '["anthropic/claude-opus-4-6"]'
         mock_response.json.return_value = [
             "anthropic/claude-opus-4-6",
             "openhands/claude-opus-4-5-20251101",
@@ -756,6 +781,8 @@ class TestCheckSaasVerifiedModel:
     def test_model_found_in_saas_with_bare_name(self, mock_get):
         """Test that a bare verified model name from the SaaS API returns True."""
         mock_response = MagicMock()
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = '["claude-sonnet-4-6"]'
         mock_response.json.return_value = [
             "claude-sonnet-4-6",
             "openhands/claude-opus-4-5-20251101",
@@ -772,6 +799,8 @@ class TestCheckSaasVerifiedModel:
     def test_model_not_found_in_saas(self, mock_get):
         """Test that non-OpenHands provider entries do not count as SaaS support."""
         mock_response = MagicMock()
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = '["anthropic/claude-opus-4-6"]'
         mock_response.json.return_value = [
             "anthropic/claude-opus-4-6",
             "zai.glm-4.7",
@@ -787,22 +816,52 @@ class TestCheckSaasVerifiedModel:
             result = check_saas_verified_model("claude-opus-4-6")
             assert result is False
 
-    def test_no_api_key_returns_false(self):
-        """Test that missing LLM_API_KEY returns False."""
+    def test_no_api_key_returns_none(self):
+        """Test that missing API keys return None (unconfirmed)."""
         with patch.dict(os.environ, {}, clear=True):
-            # Ensure LLM_API_KEY is not set
-            os.environ.pop("LLM_API_KEY", None)
             result = check_saas_verified_model("any-model")
-            assert result is False
+            assert result is None
 
     @patch("track_llm_support.requests.get")
-    def test_api_error_returns_false(self, mock_get):
-        """Test that API errors return False."""
+    def test_api_error_returns_none(self, mock_get):
+        """Test that API errors return None (unconfirmed)."""
         mock_get.side_effect = Exception("API error")
 
         with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
             result = check_saas_verified_model("any-model")
-            assert result is False
+            assert result is None
+
+    @patch("track_llm_support.requests.get")
+    def test_non_json_response_returns_none(self, mock_get):
+        """Test that an HTML response is treated as an unconfirmed SaaS check."""
+        mock_response = MagicMock()
+        mock_response.headers = {"content-type": "text/html; charset=utf-8"}
+        mock_response.text = "<html><body>OpenHands</body></html>"
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
+            result = check_saas_verified_model("any-model")
+            assert result is None
+
+    @patch("track_llm_support.requests.get")
+    def test_items_payload_is_supported(self, mock_get):
+        """Test that the config/models/search payload shape is supported."""
+        mock_response = MagicMock()
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = '{"items": []}'
+        mock_response.json.return_value = {
+            "items": [
+                {"provider": "openhands", "name": "gemini-3-pro-preview"},
+                {"provider": "anthropic", "name": "claude-opus-4-6"},
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
+            result = check_saas_verified_model("Gemini-3-Pro")
+            assert result is True
 
     @patch("track_llm_support.requests.get")
     def test_gpt54_matches_simple_alias(self, mock_get):

--- a/tests/test_track_llm_support.py
+++ b/tests/test_track_llm_support.py
@@ -804,6 +804,90 @@ class TestCheckSaasVerifiedModel:
             result = check_saas_verified_model("any-model")
             assert result is False
 
+    @patch("track_llm_support.requests.get")
+    def test_gpt54_matches_simple_alias(self, mock_get):
+        """Test that GPT-5.4 matches via its simple 'gpt-5.4' alias (not just -pro variant)."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            "openhands/gpt-5.4",
+        ]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
+            result = check_saas_verified_model("GPT-5.4")
+            assert result is True
+
+    @patch("track_llm_support.requests.get")
+    def test_minimax_m27_matches_simple_alias(self, mock_get):
+        """Test that MiniMax-M2.7 matches via its simple 'minimax-m2.7' alias."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            "openhands/minimax-m2.7",
+        ]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
+            result = check_saas_verified_model("MiniMax-M2.7")
+            assert result is True
+
+    @patch("track_llm_support.requests.get")
+    def test_kimi_k25_matches_simple_alias(self, mock_get):
+        """Test that Kimi-K2.5 matches via its simple 'kimi-k2.5' alias."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            "openhands/kimi-k2.5",
+        ]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
+            result = check_saas_verified_model("Kimi-K2.5")
+            assert result is True
+
+    @patch("track_llm_support.requests.get")
+    def test_glm47_matches_simple_alias(self, mock_get):
+        """Test that GLM-4.7 matches via its simple 'glm-4.7' alias."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            "openhands/glm-4.7",
+        ]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
+            result = check_saas_verified_model("GLM-4.7")
+            assert result is True
+
+    @patch("track_llm_support.requests.get")
+    def test_glm5_matches_simple_alias(self, mock_get):
+        """Test that GLM-5 matches via its simple 'glm-5' alias."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            "openhands/glm-5",
+        ]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
+            result = check_saas_verified_model("GLM-5")
+            assert result is True
+
+    @patch("track_llm_support.requests.get")
+    def test_qwen3_coder_next_matches_simple_alias(self, mock_get):
+        """Test that Qwen3-Coder-Next matches via its simple 'qwen3-coder-next' alias."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            "openhands/qwen3-coder-next",
+        ]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LLM_API_KEY": "test-key"}):
+            result = check_saas_verified_model("Qwen3-Coder-Next")
+            assert result is True
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- fix SaaS frontend confirmation to use the deployed `/api/v1/config/models/search?provider__eq=openhands` endpoint instead of legacy endpoints that can return the SPA shell
- preserve `frontend_support_timestamp` as frontend-code support while tracking SaaS availability separately in `frontend_saas_available`
- update the UI to distinguish `full`, `frontend_only`, `saas_only`, and `not_found`
- extend tracker/frontend tests to cover the revised frontend and SaaS semantics

## Why

The tracker could incorrectly mark `frontend_saas_available` as false because the legacy SaaS probe hit HTML responses instead of JSON. That in turn caused false regressions in completeness calculations.

## Validation

- `python -m pytest tests/test_track_llm_support.py -q`
- `cd frontend && npm test`
- `cd frontend && npm run build`

Fixes #48

_AI-generated PR update by OpenHands on behalf of the user._
