### PR TITLE
Add GLM-5.1 as tier 1 model

### DIFF
--- a/frontend/public/all_models.json
+++ b/frontend/public/all_models.json
@@ -36,6 +36,18 @@
     "litellm_support_timestamp": "2026-03-06T22:56:14+05:30"
   },
   {
+    "model_id": "GLM-5.1",
+    "release_date": "2026-04-10",
+    "tier": 1,
+    "sdk_support_timestamp": null,
+    "frontend_support_timestamp": null,
+    "frontend_saas_available": false,
+    "index_results_timestamp": null,
+    "eval_proxy_timestamp": null,
+    "prod_proxy_timestamp": null,
+    "litellm_support_timestamp": null
+  },
+  {
     "model_id": "GPT-5.2",
     "release_date": "2025-12-11",
     "tier": 1,

--- a/scripts/run_all_models.py
+++ b/scripts/run_all_models.py
@@ -39,6 +39,7 @@ MODEL_RELEASE_DATES = {
     # GLM models (Z-AI/Zhipu)
     "GLM-4.7": "2025-10-01",
     "GLM-5": "2026-02-01",
+    "GLM-5.1": "2026-04-10",
     # Google Gemini models
     "Gemini-3-Pro": "2025-11-18",
     "Gemini-3-Flash": "2025-12-17",

--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -80,6 +80,12 @@ MODEL_ALIASES: dict[str, list[str]] = {
         "zai/glm-5-code",        # Code variant
         "openrouter/z-ai/glm-5",
     ],
+    "GLM-5.1": [
+        "glm-5.1",
+        "zai/glm-5.1",          # LiteLLM direct naming
+        "zai/glm-5.1-code",     # Code variant
+        "openrouter/z-ai/glm-5.1",
+    ],
     # OpenAI GPT models
     "GPT-5.2": [
         "gpt-5.2",  # Frontend verified-models.ts

--- a/tests/test_track_llm_support.py
+++ b/tests/test_track_llm_support.py
@@ -134,6 +134,10 @@ class TestModelRegistry:
         """trinity-large-thinking should be tracked with the official release date."""
         assert MODEL_RELEASE_DATES["trinity-large-thinking"] == "2026-04-01"
 
+    def test_glm_51_release_date(self):
+        """GLM-5.1 should be tracked with the official release date."""
+        assert MODEL_RELEASE_DATES["GLM-5.1"] == "2026-04-10"
+
 
 class TestGetGithubHeaders:
     """Tests for get_github_headers function."""
@@ -190,6 +194,7 @@ class TestGetModelTier:
         """GLM models should be tier 1."""
         assert get_model_tier("GLM-4.7") == 1
         assert get_model_tier("GLM-5") == 1
+        assert get_model_tier("GLM-5.1") == 1
 
     def test_minimax_m25_m27_is_tier_1(self):
         """MiniMax-M2.5 and M2.7 should be tier 1 (M2.1 was superseded before frontend support)."""
@@ -381,6 +386,13 @@ class TestGetLitellmModelSearchTerms:
         terms = get_litellm_model_search_terms("GLM-5")
         assert "GLM-5" in terms
         assert "zai/glm-5" in terms
+
+    def test_glm51_alias(self):
+        """Test GLM-5.1 returns model ID and aliases."""
+        terms = get_litellm_model_search_terms("GLM-5.1")
+        assert "GLM-5.1" in terms
+        assert "glm-5.1" in terms
+        assert "zai/glm-5.1" in terms
 
     def test_gemini_3_pro_alias(self):
         """Test Gemini-3-Pro returns model ID and preview suffix alias."""


### PR DESCRIPTION
## Summary

This PR adds GLM-5.1 as a tier 1 model to the LLM support tracker.

### Changes Made

1. **Added GLM-5.1 to `MODEL_RELEASE_DATES`** (`scripts/run_all_models.py`):
   - Release date: 2026-04-10

2. **Added GLM-5.1 aliases** (`scripts/track_llm_support.py`):
   - `glm-5.1` (lowercase)
   - `zai/glm-5.1` (LiteLLM direct naming)
   - `zai/glm-5.1-code` (Code variant)
   - `openrouter/z-ai/glm-5.1` (OpenRouter)

3. **Added tests** (`tests/test_track_llm_support.py`):
   - `test_glm_51_release_date` - verifies release date
   - `test_glm51_alias` - verifies aliases
   - Updated `test_glm_is_tier_1` to include GLM-5.1

### Tier Classification

GLM-5.1 is automatically classified as tier 1 because it matches the existing pattern `r"^GLM-"` in `TIER_1_PATTERNS`.

Fixes #57

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4c377829-f55d-432e-91a7-009064cfb4dc)