### PR TITLE
Support Claude Opus 4.7 as a tier 1 model

### DIFF
--- a/scripts/run_all_models.py
+++ b/scripts/run_all_models.py
@@ -32,6 +32,7 @@ MODEL_RELEASE_DATES = {
     "claude-sonnet-4-6": "2026-02-20",
     "claude-opus-4-5": "2025-11-24",
     "claude-opus-4-6": "2026-02-05",
+    "claude-opus-4-7": "2026-04-14",
     # Arcee AI models
     "trinity-large-thinking": "2026-04-01",
     # DeepSeek models

--- a/scripts/run_all_models.py
+++ b/scripts/run_all_models.py
@@ -32,7 +32,7 @@ MODEL_RELEASE_DATES = {
     "claude-sonnet-4-6": "2026-02-20",
     "claude-opus-4-5": "2025-11-24",
     "claude-opus-4-6": "2026-02-05",
-    "claude-opus-4-7": "2026-04-14",
+    "claude-opus-4-7": "2026-04-16",
     # Arcee AI models
     "trinity-large-thinking": "2026-04-01",
     # DeepSeek models

--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -55,6 +55,9 @@ MODEL_ALIASES: dict[str, list[str]] = {
     "claude-opus-4-6": [
         "claude-opus-4-6",  # Frontend verified-models.ts (same name)
     ],
+    "claude-opus-4-7": [
+        # NOT YET IN FRONTEND - no aliases
+    ],
     # Arcee AI models
     "trinity-large-thinking": [
         "Trinity-Large-Thinking",

--- a/tests/test_track_llm_support.py
+++ b/tests/test_track_llm_support.py
@@ -140,7 +140,7 @@ class TestModelRegistry:
 
     def test_claude_opus_47_release_date(self):
         """claude-opus-4-7 should be tracked with the official release date."""
-        assert MODEL_RELEASE_DATES["claude-opus-4-7"] == "2026-04-14"
+        assert MODEL_RELEASE_DATES["claude-opus-4-7"] == "2026-04-16"
 
 
 class TestGetGithubHeaders:

--- a/tests/test_track_llm_support.py
+++ b/tests/test_track_llm_support.py
@@ -138,6 +138,10 @@ class TestModelRegistry:
         """GLM-5.1 should be tracked with the official release date."""
         assert MODEL_RELEASE_DATES["GLM-5.1"] == "2026-04-10"
 
+    def test_claude_opus_47_release_date(self):
+        """claude-opus-4-7 should be tracked with the official release date."""
+        assert MODEL_RELEASE_DATES["claude-opus-4-7"] == "2026-04-14"
+
 
 class TestGetGithubHeaders:
     """Tests for get_github_headers function."""
@@ -174,6 +178,7 @@ class TestGetModelTier:
         """Claude Opus models should be tier 1."""
         assert get_model_tier("claude-opus-4-5") == 1
         assert get_model_tier("claude-opus-4-6") == 1
+        assert get_model_tier("claude-opus-4-7") == 1
 
     def test_gemini_pro_flash_is_tier_1(self):
         """Gemini Pro and Flash models should be tier 1."""


### PR DESCRIPTION
## Summary

This PR adds support for Claude Opus 4.7 as a tier 1 model in the LLM Support Tracker.

### Changes Made

1. **Model Release Date** (`scripts/run_all_models.py`):
   - Added `claude-opus-4-7` with release date `2026-04-14`

2. **Model Aliases** (`scripts/track_llm_support.py`):
   - Added empty aliases entry for `claude-opus-4-7` (no aliases yet as it's not yet in frontend)

3. **Tests** (`tests/test_track_llm_support.py`):
   - Added `test_claude_opus_47_release_date` to verify the model's release date
   - Updated `test_claude_opus_is_tier_1` to verify Claude Opus 4.7 is tier 1

### Tier Classification

Claude Opus 4.7 is automatically classified as tier 1 due to the existing `r"^claude-opus-"` pattern in `TIER_1_PATTERNS`, which matches all Claude Opus models.

## Testing

All 68 tests pass:
```
GIT_TERMINAL_PROMPT=0 python -m pytest tests/test_track_llm_support.py -q
```

Fixes #60

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/204bb4f0-997f-4244-92b1-cc8250766a37)