### PR TITLE
Add GPT-5.5 as tier 1 model

### DIFF
--- a/scripts/run_all_models.py
+++ b/scripts/run_all_models.py
@@ -59,6 +59,7 @@ MODEL_RELEASE_DATES = {
     "GPT-5.2": "2025-12-11",
     "GPT-5.2-Codex": "2025-12-18",
     "GPT-5.4": "2026-03-05",
+    "GPT-5.5": "2026-04-23",
     # Alibaba Qwen models
     "Qwen3-Coder-480B": "2025-07-23",
     "Qwen3-Coder-Next": "2026-01-15",

--- a/scripts/track_llm_support.py
+++ b/scripts/track_llm_support.py
@@ -100,6 +100,10 @@ MODEL_ALIASES: dict[str, list[str]] = {
         "gpt-5.4",      # API model name
         "gpt-5.4-pro",  # Pro variant API model name
     ],
+    "GPT-5.5": [
+        "gpt-5.5",      # API model name
+        "gpt-5.5-pro",  # Pro variant API model name
+    ],
     # Google Gemini models
     "Gemini-3-Pro": [
         "gemini-3-pro-preview",  # Frontend verified-models.ts

--- a/tests/test_track_llm_support.py
+++ b/tests/test_track_llm_support.py
@@ -91,6 +91,13 @@ class TestModelAliases:
         assert "gpt-5.4" in aliases
         assert "gpt-5.4-pro" in aliases
 
+    def test_gpt55_has_aliases(self):
+        """GPT-5.5 should have API and pro variant aliases."""
+        aliases = get_model_aliases("GPT-5.5")
+        assert "GPT-5.5" in aliases
+        assert "gpt-5.5" in aliases
+        assert "gpt-5.5-pro" in aliases
+
     def test_minimax_m27_has_aliases(self):
         """MiniMax-M2.7 should have lowercase and LiteLLM aliases."""
         aliases = get_model_aliases("MiniMax-M2.7")
@@ -141,6 +148,10 @@ class TestModelRegistry:
     def test_claude_opus_47_release_date(self):
         """claude-opus-4-7 should be tracked with the official release date."""
         assert MODEL_RELEASE_DATES["claude-opus-4-7"] == "2026-04-16"
+
+    def test_gpt55_release_date(self):
+        """GPT-5.5 should be tracked with the official release date."""
+        assert MODEL_RELEASE_DATES["GPT-5.5"] == "2026-04-23"
 
 
 class TestGetGithubHeaders:
@@ -194,6 +205,7 @@ class TestGetModelTier:
         assert get_model_tier("GPT-5.2-Codex") == 1
         assert get_model_tier("GPT-5") == 1
         assert get_model_tier("GPT-5.4") == 1
+        assert get_model_tier("GPT-5.5") == 1
 
     def test_glm_is_tier_1(self):
         """GLM models should be tier 1."""


### PR DESCRIPTION
## Summary

Add GPT-5.5 as a tier 1 tracked model following its [official release on April 23, 2026](https://openai.com/index/introducing-gpt-5-5/).

## Changes

- **`scripts/run_all_models.py`**: Added `"GPT-5.5": "2026-04-23"` to `MODEL_RELEASE_DATES`
- **`scripts/track_llm_support.py`**: Added `GPT-5.5` entry to `MODEL_ALIASES` with aliases `gpt-5.5` and `gpt-5.5-pro`
- **`tests/test_track_llm_support.py`**: Added tests for release date, tier 1 classification, and alias resolution

## Notes

- GPT-5.5 is automatically classified as tier 1 by the existing `^GPT-5` pattern in `TIER_1_PATTERNS` — no pattern change needed.
- All 70 tests pass.
- **SaaS database** (`app.all-hands.dev`): Requires admin access to add `gpt-5.5` as a verified model.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1a4f4c94-fe4e-4194-9096-5c0aa351a022)