### PR TITLE
chore: use OPENHANDS_BOT_GITHUB_PAT_PUBLIC in track-llm-support

### DIFF
--- a/.github/workflows/track-llm-support.yml
+++ b/.github/workflows/track-llm-support.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Track all models
         env:
-          GITHUB_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
         run: python scripts/run_all_models.py
 
       - name: Create Pull Request


### PR DESCRIPTION
Part of [OpenHands/evaluation#428](https://github.com/OpenHands/evaluation/issues/428) (PAT blast-radius reduction).

Replaces `secrets.ALLHANDS_BOT_GITHUB_PAT` → `secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC` on L26. The `ALLHANDS_BOT_GITHUB_PAT` is the shared bot token with write access to private repos; `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` is a fine-grained PAT scoped only to public OpenHands repos (`contents+pull-requests+issues:write`).

The token is used by `scripts/run_all_models.py` for GitHub API reads; PR creation below (via `peter-evans/create-pull-request`) already uses `secrets.GITHUB_TOKEN`.

## Prerequisites

- [ ] `OpenHands/llm-support-tracker` added to the `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` fine-grained PAT allowlist
- [ ] `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` secret added to `OpenHands/llm-support-tracker` repository secrets