### PR TITLE
Fix tracker workflow credentials to restore support coverage

### DIFF
--- a/.github/workflows/track-llm-support.yml
+++ b/.github/workflows/track-llm-support.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: Track all models
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
+          GITHUB_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+          LLM_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
         run: python scripts/run_all_models.py
 
       - name: Create Pull Request


### PR DESCRIPTION
## Summary

Restore the tracker workflow environment so the scheduled/manual update job can see the same sources of truth as local runs:

- switch `GITHUB_TOKEN` back to `ALLHANDS_BOT_GITHUB_PAT` so the workflow can clone `All-Hands-AI/infra`
- pass `OPENHANDS_CLOUD_API_KEY` / `LLM_API_KEY` to the tracker job so SaaS confirmation can run when the repo secret is present

## Root cause

The latest tracker update workflow run completed successfully but logged repeated failures cloning `All-Hands-AI/infra.git`, which zeroed out many eval/prod proxy timestamps in the generated data. The workflow also had no SaaS API key, so live SaaS confirmation was unavailable.

## Validation

- compared current deployed data vs local rerun and confirmed the current code still finds the missing infra support locally
- inspected workflow run `25002951236` logs and confirmed repeated `infra.git` clone failures with the current workflow environment

_AI-generated PR by OpenHands on behalf of the user._
